### PR TITLE
Sanitize project name parameter.

### DIFF
--- a/lib/flowdock_listener.rb
+++ b/lib/flowdock_listener.rb
@@ -70,7 +70,7 @@ class FlowdockListener < Redmine::Hook::Listener
       :from_name => @user_name,
       :subject => subject,
       :content => body,
-      :project => @project_name,
+      :project => @project_name.gsub(/[^\w\s]/,' '),
       :link => @url
     }
 


### PR DESCRIPTION
As per the [Flowdock API documentation](https://www.flowdock.com/api/team-inbox) the project argument is
sanitized by replacing illegal characters with a blank space.
