### PR TITLE
token or empty string

### DIFF
--- a/app/views/settings/_redmine_flowdock.html.erb
+++ b/app/views/settings/_redmine_flowdock.html.erb
@@ -3,6 +3,6 @@
 <% Project.active.each do |project| %>
 <p>
   <%= content_tag(:label, project.name) %>
-  <%= text_field_tag("settings[api_token][#{project.identifier}]", @settings[:api_token][project.identifier]) %>
+  <%= text_field_tag("settings[api_token][#{project.identifier}]", (@settings['api_token'][project.identifier] || "")) %>
 </p>
 <% end %>

--- a/app/views/settings/_redmine_flowdock.html.erb
+++ b/app/views/settings/_redmine_flowdock.html.erb
@@ -1,8 +1,9 @@
 <p>Get your Flowdock API tokens from the <a href="https://www.flowdock.com/help/redmine" target="_blank">help page</a>. The tokens are specific to a single Flowdock flow. You can send updates to multiple flows by adding multiple tokens that are separated with a comma.</p>
 
 <% Project.active.each do |project| %>
+  <% token = if @settings.empty? then "" else @settings['api_token'][project.identifier] end %>
 <p>
   <%= content_tag(:label, project.name) %>
-  <%= text_field_tag("settings[api_token][#{project.identifier}]", (@settings['api_token'][project.identifier] || "")) %>
+  <%= text_field_tag("settings[api_token][#{project.identifier}]", token) %>
 </p>
 <% end %>


### PR DESCRIPTION
Fixes bug when projects did not yet have flow-tokens

````
ActionView::Template::Error (can't convert Symbol into Integer):
    3: <% Project.active.each do |project| %>
    4: <p>
    5:   <%= content_tag(:label, project.name) %>
    6:   <%= text_field_tag("settings[api_token][#{project.identifier}]", @settings[:api_token][project.identifier]) %>
    7: </p>
    8: <% end %>
  app/views/settings/plugin.html.erb:6:in `block in _app_views_settings_plugin_html_erb__3383405472618272837_48057540'
  app/views/settings/plugin.html.erb:4:in `_app_views_settings_plugin_html_erb__3383405472618272837_48057540'
````