### PR TITLE
Bug fix to display plugin settings view

### DIFF
--- a/app/views/settings/_redmine_flowdock.html.erb
+++ b/app/views/settings/_redmine_flowdock.html.erb
@@ -1,7 +1,7 @@
 <p>Get your Flowdock API tokens from the <a href="https://www.flowdock.com/help/redmine" target="_blank">help page</a>. The tokens are specific to a single Flowdock flow. You can send updates to multiple flows by adding multiple tokens that are separated with a comma.</p>
 
 <% Project.active.each do |project| %>
-  <% token = if @settings.empty? then "" else @settings['api_token'][project.identifier] end %>
+  <% token = if @settings.empty? || @settings['api_token'].nil? then "" else @settings['api_token'][project.identifier] end %>
 <p>
   <%= content_tag(:label, project.name) %>
   <%= text_field_tag("settings[api_token][#{project.identifier}]", token) %>


### PR DESCRIPTION
After having installed the plugin, i have got this error in my log :

```
ActionView::Template::Error (undefined method `[]' for nil:NilClass):
    1: <p>Get your Flowdock API tokens from the <a href="https://www.flowdock.com/help/redmine" target="_blank">help page</a>. The tokens are specific to a single Flowdock flow. You can send updates to multiple flows by adding multiple tokens that are separated with a comma.</p>
    2:
    3: <% Project.active.each do |project| %>
    4:   <% token = if @settings.empty? then "" else @settings['api_token'][project.identifier] end %>
    5: <p>
    6:   <%= content_tag(:label, project.name) %>
    7:   <%= text_field_tag("settings[api_token][#{project.identifier}]", token) %>
```

To fix it, I have changed the condition on settings :

```
<% token = if @settings.empty? || @settings['api_token'].nil? then "" else @settings['api_token'][project.identifier] end %>
```